### PR TITLE
refactor: copy kuromoji dict via Rsbuild output.copy

### DIFF
--- a/rsbuild.config.js
+++ b/rsbuild.config.js
@@ -1,4 +1,4 @@
-import { defineConfig, rspack } from "@rsbuild/core";
+import { defineConfig } from "@rsbuild/core";
 import { pluginNodePolyfill } from "@rsbuild/plugin-node-polyfill";
 import { pluginReact } from "@rsbuild/plugin-react";
 
@@ -6,15 +6,7 @@ export default defineConfig({
   plugins: [pluginReact(), pluginNodePolyfill()],
   output: {
     assetPrefix: "./",
-  },
-  tools: {
-    rspack: {
-      plugins: [
-        new rspack.CopyRspackPlugin({
-          patterns: [{ from: "node_modules/kuromoji/dict", to: "dict" }],
-        }),
-      ],
-    },
+    copy: [{ from: "node_modules/kuromoji/dict", to: "dict" }],
   },
   html: {
     template: "src/index.html",


### PR DESCRIPTION
## Summary

- Replace manual `CopyRspackPlugin` in `tools.rspack` with Rsbuild `output.copy`, which is implemented with the same plugin under the hood.
- Remove the unused `rspack` import and the now-empty `tools.rspack` block.

## Test plan

- [x] `npm run build` — `dist/dict/*.dat.gz` present (kuromoji dict copied)
- [ ] CI passes on this PR

Made with [Cursor](https://cursor.com)